### PR TITLE
Change inventory count behavior to distinguish between more unique versions of items

### DIFF
--- a/src/ArkInventory/ArkInventoryStorage.lua
+++ b/src/ArkInventory/ArkInventoryStorage.lua
@@ -2517,9 +2517,7 @@ function ArkInventory.ObjectIDTooltip( h )
 	
 	if class == "item" then
 		return string.format( "%s:%s:%s:%s", class, v1, v7, v8 )
-	elseif class == "empty" or class == "spell" then
-		return string.format( "%s:%s", class, v1 )
-	elseif class == "token" then
+	elseif class == "empty" or class == "spell" or class == "token" then
 		return string.format( "%s:%s", class, v1 )
 	else
 		assert( "uncoded class [" .. class .. "]" )

--- a/src/ArkInventory/ArkInventoryStorage.lua
+++ b/src/ArkInventory/ArkInventoryStorage.lua
@@ -2511,11 +2511,13 @@ end
 
 function ArkInventory.ObjectIDTooltip( h )
 	
-	local class, v1, v2 = ArkInventory.ObjectStringDecode( h )
+	local class, v1, _, _, _, _, _, v7, v8 = ArkInventory.ObjectStringDecode( h )
 	
 	--ArkInventory.Output( "class[", class, "] : [", v1, "] : [", v2, "]" )
 	
-	if class == "item" or class == "empty" or class == "spell" then
+	if class == "item" then
+		return string.format( "%s:%s:%s:%s", class, v1, v7, v8 )
+	elseif class == "empty" or class == "spell" then
 		return string.format( "%s:%s", class, v1 )
 	elseif class == "token" then
 		return string.format( "%s:%s", class, v1 )

--- a/src/ArkInventory/ArkInventoryStorage.lua
+++ b/src/ArkInventory/ArkInventoryStorage.lua
@@ -2510,17 +2510,26 @@ function ArkInventory.ObjectIDInternal( h )
 end
 
 function ArkInventory.ObjectIDTooltip( h )
-	
+
 	local class, v1, _, _, _, _, _, v7, v8 = ArkInventory.ObjectStringDecode( h )
-	
-	--ArkInventory.Output( "class[", class, "] : [", v1, "] : [", v2, "]" )
-	
+
+	-- ArkInventory.Output( "class[", class, "] : [", v1, "] : [", v2, "]" )
+
 	if class == "item" then
-		return string.format( "%s:%s:%s:%s", class, v1, v7, v8 )
+		if select(9, GetItemInfo(h)) == ( "INVTYPE_WEAPON" or "INVTYPE_WEAPONMAINHAND" or "INVTYPE_WEAPONOFFHAND" or "INVTYPE_2HWEAPON" ) then
+			return string.format( "%s:%s:0:%s", class, v1, v8 )
+
+		else
+			return string.format( "%s:%s:%s:%s", class, v1, v7, v8 )
+			
+		end
+		
 	elseif class == "empty" or class == "spell" or class == "token" then
 		return string.format( "%s:%s", class, v1 )
+		
 	else
 		assert( "uncoded class [" .. class .. "]" )
+		
 	end
 
 end


### PR DESCRIPTION
Changed inventory counts to consider affixes and forges as unique instances of that item instead of grouping them all together by base itemID. Idea stolen from RedeemedRiku and un-AI-ified. Up to you if you want to implement or not.